### PR TITLE
Add Limit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,3 +13,4 @@ if(BUILD_TESTING)
 endif()
 
 add_subdirectory(math/geo)
+add_subdirectory(math/limit)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,3 +14,4 @@ endif()
 
 add_subdirectory(math/geo)
 add_subdirectory(math/limit)
+add_subdirectory(math/utils)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,5 +13,6 @@ if(BUILD_TESTING)
 endif()
 
 add_subdirectory(math/geo)
-add_subdirectory(math/limit)
 add_subdirectory(math/utils)
+
+add_subdirectory(math/limit)

--- a/math/geo/CMakeLists.txt
+++ b/math/geo/CMakeLists.txt
@@ -3,6 +3,11 @@ target_include_directories(math_geo INTERFACE include)
 
 if(BUILD_TESTING)
   add_executable(math_geo_test test/point_test.cpp)
-  target_link_libraries(math_geo_test PRIVATE math_geo math_testing gtest_main)
+  target_link_libraries(
+    math_geo_test PRIVATE
+    math_geo
+    math_testing
+    gtest_main
+  )
   gtest_discover_tests(math_geo_test)
 endif()

--- a/math/geo/test/point_test.cpp
+++ b/math/geo/test/point_test.cpp
@@ -14,8 +14,7 @@ TEST(PointTest, MakePoint) {
 
 TEST(PointTest, Ostream) {
   math::testing::OstreamTests()
-    .test(P(3, -4), "(3, -4)")
-    .test(P(0.5, 0.0), "(0.5, 0)");
+    .test(P(3, -4), "(3, -4)");
 }
 
 TEST(PointTest, ExplicitConversion) {

--- a/math/limit/CMakeLists.txt
+++ b/math/limit/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(math_limit INTERFACE)
 target_include_directories(math_limit INTERFACE include)
+target_link_libraries(math_limit INTERFACE math_utils)
 
 if(BUILD_TESTING)
   add_executable(math_limit_test test/limit_test.cpp)

--- a/math/limit/CMakeLists.txt
+++ b/math/limit/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_library(math_limit INTERFACE)
+target_include_directories(math_limit INTERFACE include)
+
+if(BUILD_TESTING)
+  add_executable(math_limit_test test/limit_test.cpp)
+  target_link_libraries(math_limit_test PRIVATE math_limit gtest_main)
+  gtest_discover_tests(math_limit_test)
+endif()

--- a/math/limit/CMakeLists.txt
+++ b/math/limit/CMakeLists.txt
@@ -3,6 +3,11 @@ target_include_directories(math_limit INTERFACE include)
 
 if(BUILD_TESTING)
   add_executable(math_limit_test test/limit_test.cpp)
-  target_link_libraries(math_limit_test PRIVATE math_limit gtest_main)
+  target_link_libraries(
+    math_limit_test PRIVATE
+    math_limit
+    math_testing
+    gtest_main
+  )
   gtest_discover_tests(math_limit_test)
 endif()

--- a/math/limit/include/math/limit.hpp
+++ b/math/limit/include/math/limit.hpp
@@ -9,6 +9,14 @@ struct Limit {
   using value_type = T;
 
   T min, max;
+
+  auto center() const {
+    return (min + max) / 2;
+  }
+
+  auto range() const {
+    return max - min;
+  }
 };
 
 template<typename T>

--- a/math/limit/include/math/limit.hpp
+++ b/math/limit/include/math/limit.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <ostream>
+
 namespace math {
 
 template<typename T>
@@ -12,5 +14,10 @@ struct Limit {
 template<typename T>
 inline math::Limit<T> make_limit(const T& min, const T& max) {
   return {.min=min, .max=max};
+}
+
+template<typename T>
+std::ostream& operator<<(std::ostream& out, const Limit<T>& limit) {
+  return out << "{min: " << limit.min << ", max: " << limit.max << "}";
 }
 }

--- a/math/limit/include/math/limit.hpp
+++ b/math/limit/include/math/limit.hpp
@@ -17,6 +17,20 @@ struct Limit {
   auto range() const {
     return max - min;
   }
+
+  template<typename OT>
+  bool is_inside(const OT& other) const {
+    return min < max
+      ? other >= min && other <= max
+      : other >= max && other <= min;
+  }
+
+  template<typename OT>
+  bool is_outside(const OT& other) const {
+    return min < max
+      ? other < min || other > max
+      : other < max || other > min;
+  }
 };
 
 template<typename T>

--- a/math/limit/include/math/limit.hpp
+++ b/math/limit/include/math/limit.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <math/utils.hpp>
 #include <ostream>
 
 namespace math {
@@ -41,6 +42,13 @@ struct Limit {
     if (other < min) return min;
     if (other > max) return max;
     return other;
+  }
+
+  template<typename OT>
+  T fold(const OT& other) const {
+    if (min > max) return normalize().fold(other);
+    const auto range = this->range();
+    return min + math::mod(range + math::mod(other - min, range), range);
   }
 };
 

--- a/math/limit/include/math/limit.hpp
+++ b/math/limit/include/math/limit.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+namespace math {
+
+template<typename T>
+struct Limit {
+  using value_type = T;
+
+  T min, max;
+};
+
+template<typename T>
+inline math::Limit<T> make_limit(const T& min, const T& max) {
+  return {.min=min, .max=max};
+}
+}

--- a/math/limit/include/math/limit.hpp
+++ b/math/limit/include/math/limit.hpp
@@ -20,4 +20,14 @@ template<typename T>
 std::ostream& operator<<(std::ostream& out, const Limit<T>& limit) {
   return out << "{min: " << limit.min << ", max: " << limit.max << "}";
 }
+
+template<typename LT, typename RT>
+bool operator==(const Limit<LT>& lhs, const Limit<RT>& rhs) {
+  return lhs.min == rhs.min && lhs.max == rhs.max;
+}
+
+template<typename LT, typename RT>
+bool operator!=(const Limit<LT>& lhs, const Limit<RT>& rhs) {
+  return lhs.min != rhs.min || lhs.max != rhs.max;
+}
 }

--- a/math/limit/include/math/limit.hpp
+++ b/math/limit/include/math/limit.hpp
@@ -10,6 +10,11 @@ struct Limit {
 
   T min, max;
 
+  Limit<T> normalize() const {
+    if (min <= max) return *this;
+    return {.min=max, .max=min};
+  }
+
   auto center() const {
     return (min + max) / 2;
   }
@@ -20,29 +25,22 @@ struct Limit {
 
   template<typename OT>
   bool is_inside(const OT& other) const {
-    return min < max
-      ? other >= min && other <= max
-      : other >= max && other <= min;
+    if (min > max) return normalize().is_inside(other);
+    return other >= min && other <= max;
   }
 
   template<typename OT>
   bool is_outside(const OT& other) const {
-    return min < max
-      ? other < min || other > max
-      : other < max || other > min;
+    if (min > max) return normalize().is_outside(other);
+    return other < min || other > max;
   }
 
   template<typename OT>
-  auto clamp(const OT& other) const {
-    if (min < max) {
-      if (other < min) return min;
-      if (other > max) return max;
-      return other;
-    } else {
-      if (other < max) return max;
-      if (other > min) return min;
-      return other;
-    }
+  T clamp(const OT& other) const {
+    if (min > max) return normalize().clamp(other);
+    if (other < min) return min;
+    if (other > max) return max;
+    return other;
   }
 };
 

--- a/math/limit/include/math/limit.hpp
+++ b/math/limit/include/math/limit.hpp
@@ -31,6 +31,19 @@ struct Limit {
       ? other < min || other > max
       : other < max || other > min;
   }
+
+  template<typename OT>
+  auto clamp(const OT& other) const {
+    if (min < max) {
+      if (other < min) return min;
+      if (other > max) return max;
+      return other;
+    } else {
+      if (other < max) return max;
+      if (other > min) return min;
+      return other;
+    }
+  }
 };
 
 template<typename T>

--- a/math/limit/test/limit_test.cpp
+++ b/math/limit/test/limit_test.cpp
@@ -87,3 +87,22 @@ TEST(LimitTest, Clamp) {
   EXPECT_EQ(L(-0.5, 1.5).clamp(1), 1.0);
   EXPECT_EQ(L(-0.5, 1.5).clamp(2), 1.5);
 }
+
+TEST(LimitTest, Fold) {
+  EXPECT_EQ(L(-2, 2).fold(0), 0);
+  EXPECT_EQ(L(-2, 2).fold(5), 1);
+  EXPECT_EQ(L(-2, 2).fold(-5), -1);
+  // test floating point
+  EXPECT_EQ(L(-1.5, 2.75).fold(0.5), 0.5);
+  EXPECT_EQ(L(-1.5, 2.75).fold(5.75), 1.5);
+  EXPECT_EQ(L(-1.5, 2.75).fold(-9.25), -0.75);
+  // test inverted min max
+  EXPECT_EQ(L(2, -2).fold(0), 0);
+  EXPECT_EQ(L(2, -2).fold(5), 1);
+  EXPECT_EQ(L(2, -2).fold(-5), -1);
+  // test cross type
+  EXPECT_EQ(L(-2, 2).fold(0.2), 0);
+  EXPECT_EQ(L(-2, 2).fold(5.2), 1);
+  EXPECT_EQ(L(-1.5, 2.75).fold(0), 0);
+  EXPECT_EQ(L(-1.5, 2.75).fold(-9), -0.5);
+}

--- a/math/limit/test/limit_test.cpp
+++ b/math/limit/test/limit_test.cpp
@@ -25,6 +25,11 @@ TEST(LimitTest, Equality) {
     .test(L(0, 1), L(-1.0, 1.0), false);
 }
 
+TEST(LimitTest, Normalize) {
+  EXPECT_EQ(L(-1, 1).normalize(), L(-1, 1));
+  EXPECT_EQ(L(1, -1).normalize(), L(-1, 1));
+}
+
 TEST(LimitTest, Center) {
   EXPECT_EQ(L(-1, 1).center(), 0);
   EXPECT_EQ(L(0, 5).center(), 2);

--- a/math/limit/test/limit_test.cpp
+++ b/math/limit/test/limit_test.cpp
@@ -24,3 +24,13 @@ TEST(LimitTest, Equality) {
     .test(L(-1, 1), L(-1.0, 1.0), true)
     .test(L(0, 1), L(-1.0, 1.0), false);
 }
+
+TEST(LimitTest, Center) {
+  EXPECT_EQ(L(-1, 1).center(), 0);
+  EXPECT_EQ(L(0, 5).center(), 2);
+  EXPECT_EQ(L(0.0, 5.0).center(), 2.5);
+}
+
+TEST(LimitTest, Range) {
+  EXPECT_EQ(L(-1, 1).range(), 2);
+}

--- a/math/limit/test/limit_test.cpp
+++ b/math/limit/test/limit_test.cpp
@@ -34,3 +34,36 @@ TEST(LimitTest, Center) {
 TEST(LimitTest, Range) {
   EXPECT_EQ(L(-1, 1).range(), 2);
 }
+
+namespace {
+
+class InsideOutsideTests : public math::testing::BaseTests {
+ public:
+  template<typename LT, typename RT>
+  InsideOutsideTests& test(const math::Limit<LT>& limit, const RT& val, bool is_inside) {
+    EXPECT_EQ(limit.is_inside(val), is_inside) << failed_message();
+    EXPECT_EQ(limit.is_outside(val), !is_inside) << failed_message();
+    return next<InsideOutsideTests>();
+  }  // LCOV_EXCL_LINE
+};
+}
+
+TEST(LimitTest, InsideOutside) {
+  InsideOutsideTests()
+    // test inside
+    .test(L(-1, 1), 0, true)
+    .test(L(-1, 1), -1, true)
+    .test(L(-1, 1), 1, true)
+    // test outside
+    .test(L(-1, 1), -2, false)
+    .test(L(-1, 1), 3, false)
+    // test inverted min max
+    .test(L(1, -1), 0, true)
+    .test(L(1, -1), -2, false)
+    .test(L(1, -1), 3, false)
+    // test cross type
+    .test(L(-1, 1), 0.5, true)
+    .test(L(-1, 1), 2.5, false)
+    .test(L(-0.5, 1.5), 0, true)
+    .test(L(-0.5, 1.5), -1, false);
+}

--- a/math/limit/test/limit_test.cpp
+++ b/math/limit/test/limit_test.cpp
@@ -81,4 +81,9 @@ TEST(LimitTest, Clamp) {
   EXPECT_EQ(L(1, -1).clamp(0), 0);
   EXPECT_EQ(L(1, -1).clamp(-2), -1);
   EXPECT_EQ(L(1, -1).clamp(3), 1);
+  // test cross type
+  EXPECT_EQ(L(-1, 1).clamp(0.2), 0);
+  EXPECT_EQ(L(-1, 1).clamp(-2.2), -1);
+  EXPECT_EQ(L(-0.5, 1.5).clamp(1), 1.0);
+  EXPECT_EQ(L(-0.5, 1.5).clamp(2), 1.5);
 }

--- a/math/limit/test/limit_test.cpp
+++ b/math/limit/test/limit_test.cpp
@@ -67,3 +67,13 @@ TEST(LimitTest, InsideOutside) {
     .test(L(-0.5, 1.5), 0, true)
     .test(L(-0.5, 1.5), -1, false);
 }
+
+TEST(LimitTest, Clamp) {
+  EXPECT_EQ(L(-1, 1).clamp(0), 0);
+  EXPECT_EQ(L(-1, 1).clamp(-2), -1);
+  EXPECT_EQ(L(-1, 1).clamp(3), 1);
+  // test inverted min max
+  EXPECT_EQ(L(1, -1).clamp(0), 0);
+  EXPECT_EQ(L(1, -1).clamp(-2), -1);
+  EXPECT_EQ(L(1, -1).clamp(3), 1);
+}

--- a/math/limit/test/limit_test.cpp
+++ b/math/limit/test/limit_test.cpp
@@ -1,0 +1,8 @@
+#include <math/limit.hpp>
+#include <gtest/gtest.h>
+
+TEST(LimitTest, MakeLimit) {
+  const auto limit = math::make_limit(-1, 1);
+  EXPECT_EQ(limit.min, -1);
+  EXPECT_EQ(limit.max, 1);
+}

--- a/math/limit/test/limit_test.cpp
+++ b/math/limit/test/limit_test.cpp
@@ -1,8 +1,16 @@
 #include <math/limit.hpp>
+#include <math/testing/tests.hpp>
 #include <gtest/gtest.h>
+
+#define L(MIN, MAX) math::make_limit(MIN, MAX)
 
 TEST(LimitTest, MakeLimit) {
   const auto limit = math::make_limit(-1, 1);
   EXPECT_EQ(limit.min, -1);
   EXPECT_EQ(limit.max, 1);
+}
+
+TEST(LimitTest, Ostream) {
+  math::testing::OstreamTests()
+    .test(L(-1, 1), "{min: -1, max: 1}");
 }

--- a/math/limit/test/limit_test.cpp
+++ b/math/limit/test/limit_test.cpp
@@ -14,3 +14,13 @@ TEST(LimitTest, Ostream) {
   math::testing::OstreamTests()
     .test(L(-1, 1), "{min: -1, max: 1}");
 }
+
+TEST(LimitTest, Equality) {
+  math::testing::EqualityTests()
+    .test(L(-1, 1), L(-1, 1), true)
+    .test(L(0, 1), L(-1, 1), false)
+    .test(L(-1, 0), L(-1, -1), false)
+    .test(L(0, 0), L(-1, 1), false)
+    .test(L(-1, 1), L(-1.0, 1.0), true)
+    .test(L(0, 1), L(-1.0, 1.0), false);
+}

--- a/math/utils/CMakeLists.txt
+++ b/math/utils/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_library(math_utils INTERFACE)
+target_include_directories(math_utils INTERFACE include)
+
+if(BUILD_TESTING)
+  add_executable(math_utils_test test/utils_test.cpp)
+  target_link_libraries(math_utils_test PRIVATE math_utils gtest_main)
+  gtest_discover_tests(math_utils_test)
+endif()

--- a/math/utils/include/math/utils.hpp
+++ b/math/utils/include/math/utils.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <cmath>
+#include <type_traits>
+
+namespace math {
+
+template<typename LT, typename RT>
+inline auto mod(const LT& lhs, const RT& rhs) {
+  // TODO: this implementation will force type to be LT if both LT and RT are floating point
+  if constexpr (std::is_floating_point_v<LT>) {
+    return std::fmod(lhs, static_cast<LT>(rhs));
+  } else if constexpr (std::is_floating_point_v<RT>) {
+    return std::fmod(static_cast<RT>(lhs), rhs);
+  } else {
+    return lhs % rhs;
+  }
+}
+}

--- a/math/utils/test/utils_test.cpp
+++ b/math/utils/test/utils_test.cpp
@@ -1,0 +1,10 @@
+#include <math/utils.hpp>
+#include <gtest/gtest.h>
+
+TEST(UtilsTest, Mod) {
+  EXPECT_EQ(math::mod(5, 2), 1);
+  EXPECT_EQ(math::mod(4.75, 1.5), 0.25);
+  // test cross type
+  EXPECT_EQ(math::mod(5, 1.5), 0.5);
+  EXPECT_EQ(math::mod(4.75, 2), 0.75);
+}


### PR DESCRIPTION
- add `math::Limit<T>` struct inside `math_limit` module which has:
  - `normalize()` function to fix if min and max value is inverted.
  - `center()` to calculate center between min and max.
  - `range()` to calculate distance between min and max.
  - `is_inside(val)` and `is_outside` to check if a value is inside or outside limit's min and max.
  - `clamp(val)` function to make a value stay between min and max by clamping the value.
  - `fold(val)` function to make a value stay between min and max by performing modulo operation on it.
  - `std::ostream` operation
  - equaility and inequality operation.
- add `math::make_limit(x, y)` function that simplify `math::Limit<T>` creation without specifying the value type.
- add `math::mod(lhs, rhs)` function inside `math_utils` module to generalize calling of modulo operation on integral and floating point numbers.