### PR TITLE
Fix Build Badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Math
 
-[![build status](https://img.shields.io/github/workflow/status/threeal/math/build)](https://github.com/threeal/math/actions/workflows/build.yml)
+[![build status](https://img.shields.io/github/actions/workflow/status/threeal/math/build.yml?branch=main)](https://github.com/threeal/math/actions/workflows/build.yml)
 [![docs status](https://img.shields.io/readthedocs/math-cpp)](https://readthedocs.org/projects/math-cpp/builds)
 [![test result](https://img.shields.io/testspace/pass-ratio/threeal/threeal:math/main)](https://threeal.testspace.com)
 [![code coverage](https://img.shields.io/coveralls/github/threeal/math/main)](https://coveralls.io/github/threeal/math)


### PR DESCRIPTION
Fix build badge URL as mentioned in https://github.com/badges/shields/issues/8671.