### PR TITLE
Modify GitHub Workflow Trigger

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,9 +51,11 @@ jobs:
         run: ctest --verbose --test-dir build --no-compress-output -T Test || true
 
       - name: Download Testspace client
+        if: github.event_name != 'pull_request'
         run: curl -fsSL https://testspace-client.s3.amazonaws.com/testspace-linux.tgz | tar -zxvf- -C build
 
       - name: Configure Testspace client
+        if: github.event_name != 'pull_request'
         working-directory: build
         run: |
           ./testspace config url ${{ secrets.TESTSPACE_URL }}
@@ -61,6 +63,7 @@ jobs:
           ./testspace config space ${{ github.ref_name }}
 
       - name: Send test result to Testspace
+        if: github.event_name != 'pull_request'
         working-directory: build
         run: ./testspace [Tests]"Testing/*/Test.xml"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,9 @@
 name: build
 on:
   workflow_dispatch:
+  pull_request:
   push:
+    branches: [main]
 jobs:
   release:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Modify the GitHub workflow to be triggered only on pull request event and push event. The push event only triggers if the target branch is `main`. This PR also modify the build workflow to not sending test result to [Testspace](https://www.testspace.com/) if that workflow is triggered by pull request event.