### PR TITLE
Git Ignore All Dot Prefixed Files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+.*
+!.git
+
 build
-.vscode


### PR DESCRIPTION
Modify [Git](https://git-scm.com/) to ignore all dot-prefixed files (`.*`), except for git files (`.git*`).