### PR TITLE
Bump Catch2 to Version 3.5.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ cpmaddpackage("gh:TheLartians/Format.cmake@1.7.3")
 if(BUILD_TESTING)
   enable_testing()
 
-  cpmaddpackage("gh:catchorg/Catch2@3.2.0")
+  cpmaddpackage("gh:catchorg/Catch2@3.5.3")
   include("${Catch2_SOURCE_DIR}/extras/Catch.cmake")
 
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -coverage -g -O0")


### PR DESCRIPTION
This pull request simply bumps [Catch2](https://github.com/catchorg/Catch2) to the version [3.5.3](https://github.com/catchorg/Catch2/releases/tag/v3.5.3).