### PR TITLE
Remove Configure Pages Action

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -17,9 +17,6 @@ jobs:
       group: pages
       cancel-in-progress: true
     steps:
-      - name: Setup Pages
-        uses: actions/configure-pages@v5.0.0
-
       - name: Checkout
         uses: actions/checkout@v4.1.2
 


### PR DESCRIPTION
This pull request resolves #47 by removing the Configure Pages action from the Deploy Pages job.