### PR TITLE
Remove Test Coverage Check Submission to Coveralls

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,4 +54,4 @@ jobs:
         working-directory: build
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        run: gcovr -r .. --gcov-executable 'llvm-cov gcov' --exclude-directories _deps -e _deps
+        run: gcovr -r .. --gcov-executable 'llvm-cov gcov' --exclude-directories _deps -e _deps --fail-under-line 100

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,8 +54,4 @@ jobs:
         working-directory: build
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        run: gcovr -r .. --gcov-executable 'llvm-cov gcov' --exclude-directories _deps -e _deps --coveralls coverage.json
-
-      - name: Send code coverage info to Coveralls
-        working-directory: build
-        run: curl -v -F json_file=@coverage.json https://coveralls.io/api/v1/jobs
+        run: gcovr -r .. --gcov-executable 'llvm-cov gcov' --exclude-directories _deps -e _deps


### PR DESCRIPTION
This pull request resolves #49 by modifying the `test` job to not generate and send a report to Coveralls, and modifying the Gcovr command to check if the test coverage is at 100%.