### PR TITLE
Bump Catch2 to Version 3.5.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ cpmaddpackage(
 if(BUILD_TESTING)
   enable_testing()
 
-  cpmaddpackage("gh:catchorg/Catch2@3.5.3")
+  cpmaddpackage(gh:catchorg/Catch2@3.5.4)
   include("${Catch2_SOURCE_DIR}/extras/Catch.cmake")
 
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -coverage -g -O0")


### PR DESCRIPTION
This pull request simply bumps Catch2 to version [3.5.4](https://github.com/catchorg/Catch2/releases/tag/v3.5.4).