### PR TITLE
Utilize CTest Action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
         run: cmake --build build
 
       - name: Run tests
-        run: ctest --verbose --test-dir build
+        uses: threeal/ctest-action@v1.0.0
 
       - name: Install gcovr
         run: pip3 install gcovr


### PR DESCRIPTION
This pull request resolves #54 by using the [CTest Action](https://github.com/marketplace/actions/ctest-action) as a replacement for the `ctest` command to run tests for this project in the GitHub Actions workflows.