### PR TITLE
Add Option to Enable Test Targets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
         run: sudo apt install llvm ninja-build
 
       - name: Configure CMake
-        run: cmake . -B build -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -G Ninja -DBUILD_TESTING=ON
+        run: cmake . -B build -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -G Ninja -DMATH_ENABLE_TESTS=ON
 
       - name: Check for code formatting
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ set(CMAKE_CXX_STANDARD 17)
 
 project(math)
 
+option(MATH_ENABLE_TESTS "Enable test targets.")
+
 include(cmake/CPM.cmake)
 cpmaddpackage(
   GITHUB_REPOSITORY TheLartians/Format.cmake
@@ -11,7 +13,7 @@ cpmaddpackage(
   OPTIONS "FORMAT_SKIP_CMAKE ON"
 )
 
-if(BUILD_TESTING)
+if(MATH_ENABLE_TESTS)
   enable_testing()
 
   cpmaddpackage(gh:catchorg/Catch2@3.6.0)

--- a/math/geo/CMakeLists.txt
+++ b/math/geo/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_library(math_geo INTERFACE)
 target_include_directories(math_geo INTERFACE include)
 
-if(BUILD_TESTING)
+if(MATH_ENABLE_TESTS)
   add_executable(math_geo_test test/point_test.cpp)
   target_link_libraries(math_geo_test PRIVATE math_geo math_testing Catch2::Catch2WithMain)
   catch_discover_tests(math_geo_test)

--- a/math/limit/CMakeLists.txt
+++ b/math/limit/CMakeLists.txt
@@ -2,7 +2,7 @@ add_library(math_limit INTERFACE)
 target_include_directories(math_limit INTERFACE include)
 target_link_libraries(math_limit INTERFACE math_utils)
 
-if(BUILD_TESTING)
+if(MATH_ENABLE_TESTS)
   add_executable(math_limit_test test/limit_test.cpp)
   target_link_libraries(math_limit_test PRIVATE math_limit math_testing Catch2::Catch2WithMain)
   catch_discover_tests(math_limit_test)

--- a/math/utils/CMakeLists.txt
+++ b/math/utils/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_library(math_utils INTERFACE)
 target_include_directories(math_utils INTERFACE include)
 
-if(BUILD_TESTING)
+if(MATH_ENABLE_TESTS)
   add_executable(math_utils_test test/utils_test.cpp)
   target_link_libraries(math_utils_test PRIVATE math_utils Catch2::Catch2WithMain)
   catch_discover_tests(math_utils_test)


### PR DESCRIPTION
This pull request resolves #63 by adding a `MATH_ENABLE_TESTS` option to enable test targets in the project, replacing the `BUILD_TESTING` variable.