### PR TITLE
Bump Catch2 to Version 3.7.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ cpmaddpackage(
 if(MATH_ENABLE_TESTS)
   enable_testing()
 
-  cpmaddpackage(gh:catchorg/Catch2@3.7.0)
+  cpmaddpackage(gh:catchorg/Catch2@3.7.1)
   include("${Catch2_SOURCE_DIR}/extras/Catch.cmake")
 
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -coverage -g -O0")


### PR DESCRIPTION
This pull request simply bumps Catch2 to version [3.7.1](https://github.com/catchorg/Catch2/releases/tag/v3.7.1).