### PR TITLE
Specify Runner OS Version in Workflows

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   deploy-pages:
     name: Deploy Pages
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       id-token: write
       pages: write


### PR DESCRIPTION
This pull request resolves #70 by manually specifying the runner OS version to be used in workflows, replacing the default latest version.